### PR TITLE
手動のCI実行を可能にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- リリースブランチでCIの手動実行が必要
    - ただし、changesets/action が自動作成した PR の場合、workflowがトリガーされないので、手動実行を可能にする