### PR TITLE
chore(deps): bump happy-dom from 20.3.7 to 20.8.9

### DIFF
--- a/packages/rich-text-core/package.json
+++ b/packages/rich-text-core/package.json
@@ -78,6 +78,7 @@
     "@tiptap/extensions": "catalog:",
     "@tiptap/markdown": "catalog:",
     "@tiptap/pm": "catalog:",
+    "happy-dom": "catalog:",
     "lowlight": "3.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ catalogs:
     eslint-config-prettier:
       specifier: 10.1.8
       version: 10.1.8
+    happy-dom:
+      specifier: 20.8.9
+      version: 20.8.9
     knip:
       specifier: 5.82.1
       version: 5.82.1
@@ -241,13 +244,16 @@ importers:
         version: 3.10.1(@tiptap/core@3.10.1(@tiptap/pm@3.10.1))(@tiptap/pm@3.10.1)
       '@tiptap/html':
         specifier: 'catalog:'
-        version: 3.10.1(@tiptap/core@3.10.1(@tiptap/pm@3.10.1))(@tiptap/pm@3.10.1)(happy-dom@20.3.7)
+        version: 3.10.1(@tiptap/core@3.10.1(@tiptap/pm@3.10.1))(@tiptap/pm@3.10.1)(happy-dom@20.8.9)
       '@tiptap/markdown':
         specifier: 'catalog:'
         version: 3.10.1(@tiptap/core@3.10.1(@tiptap/pm@3.10.1))(@tiptap/pm@3.10.1)
       '@tiptap/pm':
         specifier: 'catalog:'
         version: 3.10.1
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.8.9
       lowlight:
         specifier: 3.3.0
         version: 3.3.0
@@ -257,7 +263,7 @@ importers:
         version: 3.10.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(vitest@4.0.18(@types/node@25.6.0)(happy-dom@20.3.7)(jiti@2.6.1)(jsdom@28.0.0))
+        version: 4.0.18(vitest@4.0.18(@types/node@25.6.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.0.0))
       jsdom:
         specifier: 28.0.0
         version: 28.0.0
@@ -266,7 +272,7 @@ importers:
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.6.0)(happy-dom@20.3.7)(jiti@2.6.1)(jsdom@28.0.0)
+        version: 4.0.18(@types/node@25.6.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.0.0)
 
 packages:
 
@@ -1526,6 +1532,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -1703,8 +1713,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  happy-dom@20.3.7:
-    resolution: {integrity: sha512-sb5IzoRl1WJKsUSRe+IloJf3z1iDq5PQ7Yk/ULMsZ5IAQEs9ZL7RsFfiKBXU7nK9QmO+iz0e59EH8r8jexTZ/g==}
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -3511,11 +3521,11 @@ snapshots:
       '@tiptap/core': 3.10.1(@tiptap/pm@3.10.1)
       '@tiptap/pm': 3.10.1
 
-  '@tiptap/html@3.10.1(@tiptap/core@3.10.1(@tiptap/pm@3.10.1))(@tiptap/pm@3.10.1)(happy-dom@20.3.7)':
+  '@tiptap/html@3.10.1(@tiptap/core@3.10.1(@tiptap/pm@3.10.1))(@tiptap/pm@3.10.1)(happy-dom@20.8.9)':
     dependencies:
       '@tiptap/core': 3.10.1(@tiptap/pm@3.10.1)
       '@tiptap/pm': 3.10.1
-      happy-dom: 20.3.7
+      happy-dom: 20.8.9
 
   '@tiptap/markdown@3.10.1(@tiptap/core@3.10.1(@tiptap/pm@3.10.1))(@tiptap/pm@3.10.1)':
     dependencies:
@@ -3707,7 +3717,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.6.0)(happy-dom@20.3.7)(jiti@2.6.1)(jsdom@28.0.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.6.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.0.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -3719,7 +3729,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.6.0)(happy-dom@20.3.7)(jiti@2.6.1)(jsdom@28.0.0)
+      vitest: 4.0.18(@types/node@25.6.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.0.0)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -3954,6 +3964,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   environment@1.1.0: {}
 
   es-module-lexer@1.7.0: {}
@@ -4179,12 +4191,12 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  happy-dom@20.3.7:
+  happy-dom@20.8.9:
     dependencies:
       '@types/node': 25.6.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
-      entities: 4.5.0
+      entities: 7.0.1
       whatwg-mimetype: 3.0.0
       ws: 8.20.0
     transitivePeerDependencies:
@@ -5093,7 +5105,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.0.18(@types/node@25.6.0)(happy-dom@20.3.7)(jiti@2.6.1)(jsdom@28.0.0):
+  vitest@4.0.18(@types/node@25.6.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.0.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1))
@@ -5117,7 +5129,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
-      happy-dom: 20.3.7
+      happy-dom: 20.8.9
       jsdom: 28.0.0
     transitivePeerDependencies:
       - jiti

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ catalog:
   '@vitest/coverage-v8': 4.0.18
   eslint: 9.39.2
   eslint-config-prettier: 10.1.8
+  happy-dom: 20.8.9
   knip: 5.82.1
   prettier: 3.8.1
   prettier-plugin-organize-imports: 4.3.0


### PR DESCRIPTION
## Summary
- happy-dom を 20.3.7 → 20.8.9 に更新（GHSA-6q6h-j7hj-3r64 / GHSA-w4gp-fjgq-3q4g 対応）
- `@craft-cross-cms/rich-text-core` の direct dependency として happy-dom を明示宣言
- catalog 経由で `20.8.9` を固定バージョンとして管理

## 背景
`@tiptap/html` は happy-dom を `peerDependencies` として宣言しているが、これまで rich-text-core 側では happy-dom を明示的に dependencies に宣言していなかった。

今回、rich-text-core に happy-dom を direct dependency として明示宣言することで、lockfile を再解決し脆弱性パッチ版 (20.8.9) に更新する。`peerDependencies` ではなく `dependencies` としたのは、rich-text-core の `/server` が happy-dom を決め打ちで使う実装（DOM 実装の差し替え余地がない）であり、consumer に追加インストールを求めない UX 方針（README の "No additional setup is needed" 記載）と整合させるため。

## Test plan
- [x] `pnpm install` 成功（lockfile 上の全 happy-dom 参照が 20.8.9 に更新）
- [x] `pnpm test` 成功（71 tests passed）
- [x] `pnpm build` 成功

Closes #50
Refs #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)