### PR TITLE
chore: add changeset for happy-dom security update (#56)

### DIFF
--- a/.changeset/happy-dom-security.md
+++ b/.changeset/happy-dom-security.md
@@ -1,0 +1,5 @@
+---
+'@craft-cross-cms/rich-text-core': patch
+---
+
+Bump happy-dom to 20.8.9 to address GHSA-6q6h-j7hj-3r64 and GHSA-w4gp-fjgq-3q4g, and declare it as a direct dependency.


### PR DESCRIPTION
## Summary

- #56 で `@craft-cross-cms/rich-text-core` の公開依存関係に `happy-dom` を追加したが changeset を同梱し忘れたため、Release ワークフローが Release PR を生成できなかった
- 遡及的に patch の changeset を追加し、`chore: version packages` の Release PR が作成されるようにする